### PR TITLE
HADOOP-10101. Guava 11 -> 21 bump

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/XAttrCommands.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/shell/XAttrCommands.java
@@ -67,7 +67,7 @@ class XAttrCommands extends FsCommand {
       "0x and 0s, respectively.\n" +
       "<path>: The file or directory.\n";
     private final static Function<String, XAttrCodec> enValueOfFunc =
-        Enums.valueOfFunction(XAttrCodec.class);
+        Enums.stringConverter(XAttrCodec.class);
 
     private String name = null;
     private boolean dump = false;

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ZKFailoverController.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/ha/ZKFailoverController.java
@@ -54,7 +54,6 @@ import org.apache.zookeeper.data.ACL;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 @InterfaceAudience.LimitedPrivate("HDFS")
@@ -509,7 +508,7 @@ public abstract class ZKFailoverController {
       doFence(target);
     } catch (Throwable t) {
       recordActiveAttempt(new ActiveAttemptRecord(false, "Unable to fence old active: " + StringUtils.stringifyException(t)));
-      Throwables.propagate(t);
+      throw t;
     }
   }
   

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/AbstractMetric.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/AbstractMetric.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.metrics2;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import static com.google.common.base.Preconditions.*;
 
@@ -84,7 +85,7 @@ public abstract class AbstractMetric implements MetricsInfo {
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("info", info)
         .add("value", value())
         .toString();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/MetricsTag.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/MetricsTag.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.metrics2;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import static com.google.common.base.Preconditions.*;
 
@@ -80,7 +81,7 @@ public class MetricsTag implements MetricsInfo {
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("info", info)
         .add("value", value())
         .toString();

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/AbstractMetricsRecord.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/AbstractMetricsRecord.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.metrics2.impl;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterables;
 
@@ -43,7 +44,7 @@ abstract class AbstractMetricsRecord implements MetricsRecord {
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("timestamp", timestamp())
         .add("name", name())
         .add("description", description())

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MsInfo.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/impl/MsInfo.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.metrics2.impl;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -48,7 +48,7 @@ public enum MsInfo implements MetricsInfo {
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("name", name()).add("description", desc)
         .toString();
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsInfoImpl.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsInfoImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.metrics2.lib;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import static com.google.common.base.Preconditions.*;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -55,7 +56,7 @@ class MetricsInfoImpl implements MetricsInfo {
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("name", name).add("description", description)
         .toString();
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MetricsRegistry.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import com.google.common.collect.Maps;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -416,7 +416,7 @@ public class MetricsRegistry {
   }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("info", metricsInfo).add("tags", tags()).add("metrics", metrics())
         .toString();
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetricsInfo.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/source/JvmMetricsInfo.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.metrics2.source;
 
-import com.google.common.base.Objects;
-
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.metrics2.MetricsInfo;
+
+import com.google.common.base.MoreObjects;
 
 /**
  * JVM and logging related metrics info instances
@@ -60,7 +60,7 @@ public enum JvmMetricsInfo implements MetricsInfo {
   @Override public String description() { return desc; }
 
   @Override public String toString() {
-  return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("name", name()).add("description", desc)
       .toString();
   }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/MetricsCache.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/util/MetricsCache.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.metrics2.AbstractMetric;
 import org.apache.hadoop.metrics2.MetricsRecord;
 import org.apache.hadoop.metrics2.MetricsTag;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 
 /**
@@ -127,7 +127,7 @@ public class MetricsCache {
     }
 
     @Override public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .add("tags", tags).add("metrics", metrics)
           .toString();
     }

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ChildReaper.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/curator/ChildReaper.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.util.curator;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import org.apache.curator.framework.recipes.locks.Reaper;
 import org.apache.curator.utils.CloseableUtils;
 import org.apache.curator.framework.CuratorFramework;
@@ -34,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -82,7 +82,7 @@ public class ChildReaper implements Closeable
    * @since 15.0
    */
   public static <E> Set<E> newConcurrentHashSet() {
-    return Sets.newSetFromMap(new ConcurrentHashMap<E, Boolean>());
+    return Collections.newSetFromMap(new ConcurrentHashMap<E, Boolean>());
   }
 
   private enum State

--- a/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInotifyEventInputStream.java
+++ b/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSInotifyEventInputStream.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hdfs;
 
-import com.google.common.collect.Iterators;
+import java.util.Collections;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.hdfs.inotify.EventBatch;
@@ -72,7 +72,7 @@ public class DFSInotifyEventInputStream {
   DFSInotifyEventInputStream(ClientProtocol namenode, Tracer tracer,
       long lastReadTxid) {
     this.namenode = namenode;
-    this.it = Iterators.emptyIterator();
+    this.it = Collections.emptyIterator();
     this.lastReadTxid = lastReadTxid;
     this.tracer = tracer;
   }

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataStorage.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/DataStorage.java
@@ -1148,7 +1148,7 @@ public class DataStorage extends Storage {
     }
     linkWorkers.shutdown();
     for (Future<Void> f : futures) {
-      Futures.get(f, IOException.class);
+      Futures.getChecked(f, IOException.class);
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/AclTransformation.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/AclTransformation.java
@@ -28,7 +28,7 @@ import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -366,7 +366,7 @@ final class AclTransformation {
     for (AclEntry entry: aclBuilder) {
       scopeFound.add(entry.getScope());
       if (entry.getType() == GROUP || entry.getName() != null) {
-        FsAction scopeUnionPerms = Objects.firstNonNull(
+        FsAction scopeUnionPerms = MoreObjects.firstNonNull(
           unionPerms.get(entry.getScope()), FsAction.NONE);
         unionPerms.put(entry.getScope(),
           scopeUnionPerms.or(entry.getPermission()));

--- a/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/JournalSet.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/JournalSet.java
@@ -64,7 +64,7 @@ public class JournalSet implements JournalManager {
     public int compare(EditLogInputStream elis1, EditLogInputStream elis2) {
       // we want local logs to be ordered earlier in the collection, and true
       // is considered larger than false, so we want to invert the booleans here
-      return ComparisonChain.start().compare(!elis1.isLocalLog(),
+      return ComparisonChain.start().compareFalseFirst(!elis1.isLocalLog(),
           !elis2.isLocalLog()).result();
     }
   };

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQJMWithFaults.java
@@ -402,7 +402,7 @@ public class TestQJMWithFaults {
 
     @Override
     protected ExecutorService createSingleThreadExecutor() {
-      return MoreExecutors.sameThreadExecutor();
+      return MoreExecutors.newDirectExecutorService();
     }
   }
 

--- a/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQuorumJournalManager.java
+++ b/hadoop-hdfs-project/hadoop-hdfs/src/test/java/org/apache/hadoop/hdfs/qjournal/client/TestQuorumJournalManager.java
@@ -946,7 +946,7 @@ public class TestQuorumJournalManager {
           protected ExecutorService createSingleThreadExecutor() {
             // Don't parallelize calls to the quorum in the tests.
             // This makes the tests more deterministic.
-            return MoreExecutors.sameThreadExecutor();
+            return MoreExecutors.newDirectExecutorService();
           }
         };
         

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -86,7 +86,7 @@
     <apacheds.version>2.0.0-M15</apacheds.version>
 
     <!-- define the Java language version used by the compiler -->
-    <javac.version>1.7</javac.version>
+    <javac.version>1.8</javac.version>
 
     <!-- The java version enforced by the maven enforcer -->
     <!-- more complex patterns can be used here, such as

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -434,7 +434,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>11.0.2</version>
+        <version>21.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -75,8 +75,8 @@
     <protobuf.version>2.5.0</protobuf.version>
     <protoc.path>${env.HADOOP_PROTOC_PATH}</protoc.path>
 
-    <zookeeper.version>3.4.6</zookeeper.version>
-    <curator.version>2.7.1</curator.version>
+    <zookeeper.version>3.4.9</zookeeper.version>
+    <curator.version>2.12.0</curator.version>
     <findbugs.version>3.0.0</findbugs.version>
 
     <tomcat.version>6.0.48</tomcat.version>

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/ApplicationSubmissionContextPBImpl.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/api/records/impl/pb/ApplicationSubmissionContextPBImpl.java
@@ -273,7 +273,7 @@ extends ApplicationSubmissionContext {
             "maximum allowed length of a tag is " +
             YarnConfiguration.APPLICATION_MAX_TAG_LENGTH);
       }
-      if (!CharMatcher.ASCII.matchesAllOf(tag)) {
+      if (!CharMatcher.ascii().matchesAllOf(tag)) {
         throw new IllegalArgumentException("A tag can only have ASCII " +
             "characters! Invalid tag - " + tag);
       }

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/WebApp.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-common/src/main/java/org/apache/hadoop/yarn/webapp/WebApp.java
@@ -262,7 +262,7 @@ public abstract class WebApp extends ServletModule {
 
   static String getPrefix(String pathSpec) {
     int start = 0;
-    while (CharMatcher.WHITESPACE.matches(pathSpec.charAt(start))) {
+    while (CharMatcher.whitespace().matches(pathSpec.charAt(start))) {
       ++start;
     }
     if (pathSpec.charAt(start) != '/') {
@@ -278,7 +278,7 @@ public abstract class WebApp extends ServletModule {
     char c;
     do {
       c = pathSpec.charAt(--ci);
-    } while (c == '/' || CharMatcher.WHITESPACE.matches(c));
+    } while (c == '/' || CharMatcher.whitespace().matches(c));
     return pathSpec.substring(start, ci + 1);
   }
 

--- a/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
+++ b/hadoop-yarn-project/hadoop-yarn/hadoop-yarn-server/hadoop-yarn-server-resourcemanager/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/ClientRMService.java
@@ -1179,7 +1179,7 @@ public class ClientRMService extends AbstractService implements
         new RMAppMoveEvent(applicationId, request.getTargetQueue(), future));
     
     try {
-      Futures.get(future, YarnException.class);
+      Futures.getChecked(future, YarnException.class);
     } catch (YarnException ex) {
       RMAuditLogger.logFailure(callerUGI.getShortUserName(),
           AuditConstants.MOVE_APP_REQUEST, "UNKNOWN", "ClientRMService",


### PR DESCRIPTION
cherry-pick of https://github.com/apache/hadoop/commit/84ddedc0b2d58257d45c16ee5e83b15f94a7ba3a

Changes:
- ``Enums.valueOfFunction`` -> ``Enums.stringConverter`` (removed in guava18)
-  ``Throwables.propagate(t);`` -> ``throw t`` (deprecated function, but not required change)
- package move of ``Objects`` -> ``MoreObjects``(moved in guava18, bulk of changes)
- ``Sets.newSetFromMap`` -> ``Collections.newSetFromMap`` (deprecated function, but not required change)
- ``Iterators.emptyIterator`` -> ``java.util.Collections.emptyIterator();`` (required change, Iterators.emptyIterator no longer public as of guava 20)
- `` ComparisonChain.start().compare`` -> ``ComparisonChain.start().compareFalseFirst`` (deprecated function, but not required change)
- ``MoreExecutors.sameThreadExecutor();`` -> ``MoreExecutors.newDirectExecutorService();`` (https://github.com/google/guava/wiki/Release21#commonutilconcurrent)
``CharMatcher.ASCII`` and ``CharMatcher.WHITESPACE`` moved to ``CharMatcher.ascii()`` and ``CharMatcher.whitespace()`` (deprecated constants, equivalent changes, not required change)
