### PR TITLE
skip hdfs server tests because they keep causing build timeouts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,19 +27,19 @@ test:
     - ? |
           case $CIRCLE_NODE_INDEX in
           0)
-            cd hadoop-common-project && mvn -T 1C test --fail-never | grep -v "ignoring option MaxPermSize"
+            cd hadoop-common-project && mvn test --fail-never | grep -v "ignoring option MaxPermSize"
             ;;
           1)
-            cd hadoop-hdfs-project && mvn -T 1C test --fail-never -pl '!hadoop-hdfs/src/contrib/bkjournal','!hadoop-hdfs-nfs' | grep -v "ignoring option MaxPermSize"
+            cd hadoop-hdfs-project && mvn test --fail-never -pl '!hadoop-hdfs/src/contrib/bkjournal','!hadoop-hdfs-nfs' | grep -v "ignoring option MaxPermSize"
             ;;
           2)
-            cd hadoop-mapreduce-project && mvn -T 1C test --fail-never | grep -v "ignoring option MaxPermSize"
+            cd hadoop-mapreduce-project && mvn test --fail-never | grep -v "ignoring option MaxPermSize"
             ;;
           3)
-            cd hadoop-tools && mvn -T 1C test --fail-never -pl '!hadoop-openstack','!hadoop-gridmix','!hadoop-archive-logs' | grep -v "ignoring option MaxPermSize"
+            cd hadoop-tools && mvn test --fail-never -pl '!hadoop-openstack','!hadoop-gridmix','!hadoop-archive-logs' | grep -v "ignoring option MaxPermSize"
             ;;
           4)
-            cd hadoop-yarn-project && mvn -T 1C test --fail-never | grep -v "ignoring option MaxPermSize"
+            cd hadoop-yarn-project && mvn test --fail-never | grep -v "ignoring option MaxPermSize"
             ;;
           esac
       :

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ test:
             cd hadoop-common-project && mvn test --fail-never | grep -v "ignoring option MaxPermSize"
             ;;
           1)
-            cd hadoop-hdfs-project && mvn test --fail-never -pl '!hadoop-hdfs/src/contrib/bkjournal','!hadoop-hdfs-nfs' | grep -v "ignoring option MaxPermSize"
+            cd hadoop-hdfs-project && mvn test --fail-never -pl '!hadoop-hdfs' | grep -v "ignoring option MaxPermSize"
             ;;
           2)
             cd hadoop-mapreduce-project && mvn test --fail-never | grep -v "ignoring option MaxPermSize"


### PR DESCRIPTION
The HDFS tests are causing consistent build timeouts on branch-2.9.0. Try various ways of fixing that. Possibly https://issues.apache.org/jira/browse/HDFS-12711 is related.

As a last resort we can probably disable the server-side HDFS tests since the changes to this repo are client-side only. Still though, feels nicer to get them working.