### PR TITLE
upgrade aws-java-sdk from 1.11.199 to 1.11.201

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -130,7 +130,7 @@
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <surefire.fork.timeout>900</surefire.fork.timeout>
-    <aws-java-sdk.version>1.11.199</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.201</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <frontend-maven-plugin.version>1.5</frontend-maven-plugin.version>
     <!-- the version of Hadoop declared in the version resources; can be overridden


### PR DESCRIPTION
Useful for reasons associated with an internal library and https://github.com/aws/aws-sdk-java/issues/1256#issuecomment-331214701. All s3a integration tests pass except for those that fail because we revert HADOOP-13188.