### PR TITLE
Fix memory leak in MutableQuantiles

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/metrics2/lib/MutableQuantiles.java
@@ -107,7 +107,7 @@ public class MutableQuantiles extends MutableMetric {
     estimator = new SampleQuantiles(quantiles);
 
     this.interval = interval;
-    scheduledTask = scheduler.scheduleAtFixedRate(new RolloverSample(this),
+    scheduledTask = scheduler.scheduleWithFixedDelay(new RolloverSample(this),
         interval, interval, TimeUnit.SECONDS);
   }
 


### PR DESCRIPTION
In some circumstances (high GC, high CPU usage, creating lots of
S3AFileSystem) it is possible for MutableQuantiles::scheduler to fall
behind processing tasks that are submitted to it; because tasks are
submitted on a regular schedule, the unbounded queue backing the
ExecutorService might grow to several gigs. By using
scheduleWithFixedDelay we ensure that under pressure this leak can't
happen.