### PR TITLE
[RFC] Throw on failure to delete during cleanupJob

### DIFF
--- a/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
+++ b/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/output/FileOutputCommitter.java
@@ -507,7 +507,10 @@ public class FileOutputCommitter extends OutputCommitter {
       // deleted by previous AM, we should tolerate FileNotFoundException in
       // this case.
       try {
-        fs.delete(pendingJobAttemptsPath, true);
+        if (!fs.delete(pendingJobAttemptsPath, true)) {
+          throw new IOException("Failed to cleanup "
+              + pendingJobAttemptsPath);
+        }
       } catch (FileNotFoundException e) {
         if (!isCommitJobRepeatable(context)) {
           throw e;


### PR DESCRIPTION
It can happen that commitTask can fail and retry, eventually succeeding, but this would leave temporary spark files around. If the `FileSystem.delete()` implementation doesn't throw on errors but just returns `fail`, then the cleanupJob can fail silently, as it is never checked if the `FileSystem.delete()` call actually returns true or false.

With this PR we're throwing an exception in case of failure of cleanupJob to avoid succeeding the job in case of cleanup failures.

Testing to be added or not, RFC first.