### PR TITLE
Enable DistCp to sync snapshot diff to blob storage filesystems

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java
@@ -80,7 +80,7 @@ public class DistCp extends Configured implements Tool {
   private boolean submitted;
   private FileSystem jobFS;
 
-  private void prepareFileListing(Job job) throws Exception {
+  protected void prepareFileListing(Job job) throws Exception {
     if (context.shouldUseSnapshotDiff()) {
       // When "-diff" or "-rdiff" is passed, do sync() first, then
       // create copyListing based on snapshot diff.
@@ -376,7 +376,7 @@ public class DistCp extends Configured implements Tool {
    * @return Returns the path where the copy listing is created
    * @throws IOException - If any
    */
-  private Path createInputFileListingWithDiff(Job job, DistCpSync distCpSync)
+  protected Path createInputFileListingWithDiff(Job job, DistCpSync distCpSync)
       throws IOException {
     Path fileListingPath = getFileListingPath();
     CopyListing copyListing = new SimpleCopyListing(job.getConfiguration(),

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpSync.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.tools;
 
 import org.apache.hadoop.HadoopIllegalArgumentException;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,7 +49,9 @@ import java.util.HashSet;
  * target since s1. All the files/directories in the target are the same with
  * source.s1
  */
-class DistCpSync {
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class DistCpSync {
   private DistCpContext context;
   private Configuration conf;
   // diffMap maps snapshot diff op type to a list of diff ops.
@@ -187,7 +191,7 @@ class DistCpSync {
    * EnumMap whose key is DiffType, and value is a DiffInfo list. If there is
    * no entry for a given DiffType, the associated value will be an empty list.
    */
-  private boolean getAllDiffs() throws IOException {
+  public boolean getAllDiffs() throws IOException {
     Path ssDir = isRdiff()?
         context.getTargetPath() : context.getSourcePaths().get(0);
 


### PR DESCRIPTION
This PR enables clients of DistCp to override the prepareFileListing method. The goal is to call getAllDiffs method from class DistCpSync to generate a listing of files that have been added from the snapshot diff. And skip method preSyncCheck since blob storage will not satisfy all requirements for the destination filesystem.