### PR TITLE
[2.x] Upgrade commons-configuration:commons-configuration to 1.7

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -817,7 +817,7 @@
       <dependency>
         <groupId>commons-configuration</groupId>
         <artifactId>commons-configuration</artifactId>
-        <version>1.6</version>
+        <version>1.7</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
`commons-configuration:commons-configuration:1.6` depends on `commons-beanutils:commons-beanutils-core`, which was deprecated and replaced with `commons-beanutils:commons-beanutils` a long time ago.

This is causing classpath conflicts because our classpath contains both:
- `commons-beanutils:commons-beanutils-core`
- `commons-beanutils:commons-beanutils`

`commons-configuration:commons-configuration:1.7` switches to depending on `commons-beanutils:commons-beanutils`.
https://mvnrepository.com/artifact/commons-configuration/commons-configuration/1.6
https://mvnrepository.com/artifact/commons-configuration/commons-configuration/1.7

There is no upstream patch for this.
https://github.com/apache/hadoop/blob/branch-2.9.2/hadoop-project/pom.xml#L820

This is fixed in hadoop 3.x by https://github.com/apache/hadoop/commit/c0b1a44f6c6e6f9e4ac5cecea0d4a50e237a4c9c.