### PR TITLE
[2.x] Upgrade javax.servlet.jsp:jsp-api to 2.1.1

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -602,7 +602,7 @@
       <dependency>
         <groupId>javax.servlet.jsp</groupId>
         <artifactId>jsp-api</artifactId>
-        <version>2.1</version>
+        <version>2.1.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
`javax.servlet.jsp:jsp-api:2.1` directly includes the `javax.el` API classes from el-api. This causes classpath conflicts.

`javax.servlet.jsp:jsp-api:2.1.1` instead depends on the correct el-api package to avoid duplicate classes on the classpath.
https://mvnrepository.com/artifact/javax.servlet.jsp/jsp-api/2.1
https://mvnrepository.com/artifact/javax.servlet.jsp/jsp-api/2.1.1

This is not fixed upstream in either the 2.x or 3.x branches.

I've opened an upstream PR on the 3.x branch in https://github.com/apache/hadoop/pull/2474.