### PR TITLE
Add option in DistCp to only copy files matching filter regexes

### DIFF
--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/CopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/CopyFilter.java
@@ -54,7 +54,9 @@ public abstract class CopyFilter {
     } else {
       String filterFilename = conf.get(
           DistCpConstants.CONF_LABEL_FILTERS_FILE);
-      return new RegexCopyFilter(filterFilename);
+      boolean useIncludeFilter = conf.getBoolean(
+          DistCpConstants.CONF_LABEL_USE_INCLUDE_FILTER, false);
+      return new RegexCopyFilter(filterFilename, useIncludeFilter);
     }
   }
 }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpConstants.java
@@ -86,6 +86,8 @@ public final class DistCpConstants {
   public static final String CONF_LABEL_SPLIT_RATIO =
       "distcp.dynamic.split.ratio";
   public static final String CONF_LABEL_DIRECT_WRITE = "distcp.direct.write";
+  public static final String CONF_LABEL_USE_INCLUDE_FILTER =
+      "distcp.filters.include";
 
   /* Total bytes to be copied. Updated by copylisting. Unfiltered count */
   public static final String CONF_LABEL_TOTAL_BYTES_TO_BE_COPIED = "mapred.total.bytes.expected";

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpContext.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpContext.java
@@ -183,6 +183,10 @@ public class DistCpContext {
     return options.shouldDirectWrite();
   }
 
+  public boolean shouldUseIncludeFilter() {
+    return options.shouldUseIncludeFilter();
+  }
+
   public void setTargetPathExists(boolean targetPathExists) {
     this.targetPathExists = targetPathExists;
   }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptionSwitch.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptionSwitch.java
@@ -235,7 +235,14 @@ public enum DistCpOptionSwitch {
    */
   DIRECT_WRITE(DistCpConstants.CONF_LABEL_DIRECT_WRITE,
       new Option("direct", false, "Write files directly to the"
-          + " target location, avoiding temporary file rename."));
+          + " target location, avoiding temporary file rename.")),
+
+  /**
+   * Paths in filters file are included in the copy. Everything else is excluded.
+   */
+  USE_INCLUDE_FILTER(DistCpConstants.CONF_LABEL_USE_INCLUDE_FILTER,
+    new Option("useIncludeFilter", false, "Paths in filters file are"
+      + " included in the copy. Everything else is excluded."));
 
 
   public static final String PRESERVE_STATUS_DEFAULT = "-prbugpct";

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCpOptions.java
@@ -158,6 +158,9 @@ public final class DistCpOptions {
   /** Whether data should be written directly to the target paths. */
   private final boolean directWrite;
 
+  /** Paths in filtersFile will be used to include paths instead of exclude them. */
+  private final boolean useIncludeFilter;
+
   /**
    * File attributes for preserve.
    *
@@ -221,6 +224,8 @@ public final class DistCpOptions {
     this.trackPath = builder.trackPath;
 
     this.directWrite = builder.directWrite;
+
+    this.useIncludeFilter = builder.useIncludeFilter;
   }
 
   public Path getSourceFileListing() {
@@ -352,6 +357,10 @@ public final class DistCpOptions {
     return directWrite;
   }
 
+  public boolean shouldUseIncludeFilter() {
+    return useIncludeFilter;
+  }
+
   /**
    * Add options to configuration. These will be used in the Mapper/committer
    *
@@ -402,6 +411,8 @@ public final class DistCpOptions {
     }
     DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.DIRECT_WRITE,
             String.valueOf(directWrite));
+    DistCpOptionSwitch.addToConf(conf, DistCpOptionSwitch.USE_INCLUDE_FILTER,
+            String.valueOf(useIncludeFilter));
   }
 
   /**
@@ -439,6 +450,7 @@ public final class DistCpOptions {
         ", copyBufferSize=" + copyBufferSize +
         ", verboseLog=" + verboseLog +
         ", directWrite=" + directWrite +
+        ", useIncludeFilter=" + useIncludeFilter +
         '}';
   }
 
@@ -489,6 +501,7 @@ public final class DistCpOptions {
             DistCpConstants.COPY_BUFFER_SIZE_DEFAULT;
 
     private boolean directWrite = false;
+    private boolean useIncludeFilter = false;
 
     public Builder(List<Path> sourcePaths, Path targetPath) {
       Preconditions.checkArgument(sourcePaths != null && !sourcePaths.isEmpty(),
@@ -598,6 +611,11 @@ public final class DistCpOptions {
       if (verboseLog && logPath == null) {
         throw new IllegalArgumentException(
             "-v is valid only with -log option");
+      }
+
+      if (useIncludeFilter && StringUtils.isBlank(filtersFile)) {
+        throw new IllegalArgumentException(
+            "-useIncludeFilter is valid only with -filters option");
       }
     }
 
@@ -745,6 +763,11 @@ public final class DistCpOptions {
 
     public Builder withDirectWrite(boolean newDirectWrite) {
       this.directWrite = newDirectWrite;
+      return this;
+    }
+
+    public Builder withUseIncludeFilter(boolean newUseIncludeFilter) {
+      this.useIncludeFilter = newUseIncludeFilter;
       return this;
     }
   }

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/OptionsParser.java
@@ -115,7 +115,9 @@ public class OptionsParser {
         .withVerboseLog(
             command.hasOption(DistCpOptionSwitch.VERBOSE_LOG.getSwitch()))
         .withDirectWrite(
-            command.hasOption(DistCpOptionSwitch.DIRECT_WRITE.getSwitch()));
+            command.hasOption(DistCpOptionSwitch.DIRECT_WRITE.getSwitch()))
+        .withUseIncludeFilter(
+            command.hasOption(DistCpOptionSwitch.USE_INCLUDE_FILTER.getSwitch()));
 
     if (command.hasOption(DistCpOptionSwitch.DIFF.getSwitch())) {
       String[] snapshots = getVals(command,

--- a/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/RegexCopyFilter.java
+++ b/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/RegexCopyFilter.java
@@ -46,14 +46,24 @@ public class RegexCopyFilter extends CopyFilter {
   private static final Logger LOG = LoggerFactory.getLogger(RegexCopyFilter.class);
   private File filtersFile;
   private List<Pattern> filters;
+  private boolean useIncludeFilter;
 
   /**
    * Constructor, sets up a File object to read filter patterns from and
    * the List to store the patterns.
    */
   protected RegexCopyFilter(String filtersFilename) {
+    this(filtersFilename, false);
+  }
+
+  /**
+   * Constructor, sets up a File object to read filter patterns from and
+   * the List to store the patterns. And sets up flag to use include filter.
+   */
+  protected RegexCopyFilter(String filtersFilename, boolean useIncludeFilterOption) {
     filtersFile = new File(filtersFilename);
     filters = new ArrayList<>();
+    useIncludeFilter = useIncludeFilterOption;
   }
 
   /**
@@ -96,9 +106,9 @@ public class RegexCopyFilter extends CopyFilter {
   public boolean shouldCopy(Path path) {
     for (Pattern filter : filters) {
       if (filter.matcher(path.toString()).matches()) {
-        return false;
+        return useIncludeFilter;
       }
     }
-    return true;
+    return !useIncludeFilter;
   }
 }

--- a/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
+++ b/hadoop-tools/hadoop-distcp/src/test/java/org/apache/hadoop/tools/TestDistCpOptions.java
@@ -289,7 +289,7 @@ public class TestDistCpOptions {
         "atomicWorkPath=null, logPath=null, sourceFileListing=abc, " +
         "sourcePaths=null, targetPath=xyz, filtersFile='null', " +
         "blocksPerChunk=0, copyBufferSize=8192, verboseLog=false, " +
-        "directWrite=false}";
+        "directWrite=false, useIncludeFilter=false}";
     String optionString = option.toString();
     Assert.assertEquals(val, optionString);
     Assert.assertNotSame(DistCpOptionSwitch.ATOMIC_COMMIT.toString(),


### PR DESCRIPTION
DistCp has a -filters flag that will exclude all file paths matching regexes provided in the filter from being copied. This new option will invert that behavior and only copy files paths that do match the filter regexes. 

This is a deliberate divergence from Apache Hadoop to enable the use of DistCp to copy new transactions in Foundry from one filesystem to another in large batches. The code change shouldn't affect any behavior outside of DistCp.